### PR TITLE
APP-4269 Add in tracking option

### DIFF
--- a/lib/delayed_resque/message_sending.rb
+++ b/lib/delayed_resque/message_sending.rb
@@ -32,7 +32,7 @@ module DelayedResque
       end
 
       if @options[:tracked].present?
-        DelayedResque::DelayProxy.track_key(@options[:tracked])
+        ::DelayedResque::DelayProxy.track_key(@options[:tracked])
         stored_options[TRACKED_QUEUE_KEY] = @options[:tracked]
       end
 

--- a/lib/delayed_resque/message_sending.rb
+++ b/lib/delayed_resque/message_sending.rb
@@ -19,12 +19,12 @@ module DelayedResque
     end
 
     def self.untrack_task(key)
-      Resque.redis.srem(TRACKED_QUEUE_NAME, key)
+      ::Resque.redis.srem(TRACKED_QUEUE_NAME, key)
     end
 
     def self.args_tracking_key(args)
       args_hash = Array(args).first
-      args_hash[TRACKED_QUEUE_KEY].presence if args_hash.is_a?(Hash)
+      args_hash[TRACKED_QUEUE_KEY].presence if args_hash.is_a?(::Hash)
     end
 
     def method_missing(method, *args)

--- a/lib/delayed_resque/message_sending.rb
+++ b/lib/delayed_resque/message_sending.rb
@@ -10,19 +10,28 @@ module DelayedResque
       @options = {:queue => "default"}.update(options)
     end
 
-    def self.is_tracked?(key)
+    def self.tracked_task?(key)
       ::Resque.redis.sismember(TRACKED_QUEUE_NAME, key)
     end
 
-    def self.track_key(key)
+    def self.track_task(key)
       ::Resque.redis.sadd(TRACKED_QUEUE_NAME, key)
+    end
+
+    def self.untrack_task(key)
+      Resque.redis.srem(TRACKED_QUEUE_NAME, key)
+    end
+
+    def self.args_tracking_key(args)
+      args_hash = Array(args).first
+      args_hash[TRACKED_QUEUE_KEY].presence if args_hash.is_a?(Hash)
     end
 
     def method_missing(method, *args)
       queue = @options[:queue] || @payload_class.queue
       performable = @payload_class.new(@target, method.to_sym, @options, args)
       stored_options = performable.store
-      
+
       if @options[:unique]
         if @options[:at] or @options[:in]
           ::Resque.remove_delayed(@payload_class, stored_options)
@@ -32,14 +41,14 @@ module DelayedResque
       end
 
       if @options[:tracked].present?
-        ::DelayedResque::DelayProxy.track_key(@options[:tracked])
+        ::DelayedResque::DelayProxy.track_task(@options[:tracked])
         stored_options[TRACKED_QUEUE_KEY] = @options[:tracked]
       end
 
       ::Rails.logger.warn("Queuing for RESQUE: #{stored_options['method']}: #{stored_options.inspect}")
-      
+
       if @options[:at]
-        ::Resque.enqueue_at(@options[:at], @payload_class, stored_options) 
+        ::Resque.enqueue_at(@options[:at], @payload_class, stored_options)
       elsif @options[:in]
         ::Resque.enqueue_in(@options[:in], @payload_class, stored_options)
       else
@@ -47,8 +56,8 @@ module DelayedResque
       end
     end
   end
-  
-  
+
+
   module MessageSending
     def delay(options = {})
       DelayProxy.new(PerformableMethod, self, options)

--- a/spec/delayed_resque_spec.rb
+++ b/spec/delayed_resque_spec.rb
@@ -85,7 +85,7 @@ describe DelayedResque do
 
     it "adds tracking key to redis" do
       DummyObject.delay(tracked: "4").first_method(123)
-      DelayedResque::DelayProxy.is_tracked?("4").should eq(true)
+      DelayedResque::DelayProxy.tracked_task?("4").should eq(true)
     end
 
   end

--- a/spec/delayed_resque_spec.rb
+++ b/spec/delayed_resque_spec.rb
@@ -5,42 +5,42 @@ describe DelayedResque do
     ResqueSpec.reset!
   end
 
-  class DummyObject      
+  class DummyObject
     include DelayedResque::MessageSending
     @queue = "default"
-  
+
     def self.first_method(param)
     end
   end
-  
+
   context "class methods can be delayed" do
     it "can delay method" do
       DummyObject.delay.first_method(123)
       DelayedResque::PerformableMethod.should have_queued({"obj"=>"CLASS:DummyObject", "method"=>:first_method, "args"=>[123]}).in(:default)
     end
-    
+
     it "delayed method is called" do
       DummyObject.stub(:second_method).with(123, 456)
       with_resque do
         DummyObject.delay.second_method(123, 456)
       end
     end
-    
+
     it "can't delay missing method" do
       expect {
         DummyObject.delay.non_existent_method
       }.to raise_error(NoMethodError)
     end
-    
+
     it "can pass additional params" do
       DummyObject.delay(:params => {"k" => "v"}).first_method(123)
       DelayedResque::PerformableMethod.should have_queued({"obj"=>"CLASS:DummyObject", "method"=>:first_method, "args"=>[123], "k" => "v"}).in(:default)
     end
-    
+
   end
-  
+
   context "active record methods can be delayed" do
-  
+
     ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'dummy_models'")
     ActiveRecord::Base.connection.create_table(:dummy_models) do |t|
       t.integer :value
@@ -51,13 +51,13 @@ describe DelayedResque do
         self.value = new_value1 + new_value2
         save!
       end
-      
+
       def copy_value(record)
         self.value = record.value
         save!
       end
     end
-    
+
     it "can delay method" do
       record = DummyModel.create(:value => 1)
       with_resque do
@@ -65,7 +65,7 @@ describe DelayedResque do
       end
       record.reload.value.should eq(10)
     end
-    
+
     it "AR model can be parameter to delay" do
       record1 = DummyModel.create(:value => 1)
       record2 = DummyModel.create(:value => 3)
@@ -74,15 +74,28 @@ describe DelayedResque do
       end
       record1.reload.value.should eq(3)
     end
-    
+
   end
-  
+
+  context "tasks can be tracked" do
+    it "adds tracking params tasks" do
+      DummyObject.delay(tracked: "4").first_method(123)
+      DelayedResque::PerformableMethod.should have_queued({"obj"=>"CLASS:DummyObject", "method"=>:first_method, "args"=>[123], "tracked_task_key"=> "4"}).in(:default)
+    end
+
+    it "adds tracking key to redis" do
+      DummyObject.delay(tracked: "4").first_method(123)
+      DelayedResque::DelayProxy.is_tracked?("4").should eq(true)
+    end
+
+  end
+
   context "methods can be delayed for an interval" do
     it "can delay method" do
       DummyObject.delay(:in => 5.minutes).first_method(123)
       DelayedResque::PerformableMethod.should have_scheduled({"obj"=>"CLASS:DummyObject", "method"=>:first_method, "args"=>[123]}).in(5 * 60)
     end
-    
+
     it "can run at specific time" do
       at_time = Time.now.utc + 10.minutes
       DummyObject.delay(:at => at_time).first_method(123)
@@ -90,7 +103,7 @@ describe DelayedResque do
       DelayedResque::PerformableMethod.should have_schedule_size_of(1)
     end
   end
-  
+
   context "unique jobs" do
     it "can remove preceeding jobs" do
       DummyObject.delay.first_method(123)
@@ -101,7 +114,7 @@ describe DelayedResque do
       DummyObject.delay(:unique => true).first_method(123)
       DelayedResque::PerformableMethod.should have_queue_size_of(2)
     end
-    
+
     it "can remove preceeding delayed jobs" do
       at_time = Time.now.utc + 10.minutes
       DummyObject.delay(:at => at_time).first_method(123)


### PR DESCRIPTION
Dearest Reviewer,

Some items we want to delay need to be tracked in a faster fashion.
This allows us to optionally add in a tracking key that we will catch
on the way out.

Changes:
Added tracked option and related magic keys

Becker