### PR TITLE
PF-163 resque unique job handling

### DIFF
--- a/lib/delayed_resque.rb
+++ b/lib/delayed_resque.rb
@@ -1,5 +1,6 @@
 require 'resque'
 require 'resque-scheduler'
+require File.dirname(__FILE__) + '/delayed_resque/meta_data'
 require File.dirname(__FILE__) + '/delayed_resque/message_sending'
 require File.dirname(__FILE__) + '/delayed_resque/performable_method'
 

--- a/lib/delayed_resque/message_sending.rb
+++ b/lib/delayed_resque/message_sending.rb
@@ -55,8 +55,13 @@ module DelayedResque
             # instead.
             ::Rails.logger.warn("Trying to throttle a non-scheduled job, which is unsupported.")
           end
-        else
-          # Ensure that the meta data is specific to the job.
+        end
+
+        unless @options[:unique]
+          # Ensure that the meta data is specific to the job. Since multiple
+          # jobs might appear in the queue with the same options, we need
+          # to add a unique aspect to the options so only one instance of the
+          # meta data matches.
           stored_options["unique_meta_id"] = ::SecureRandom.uuid
         end
 

--- a/lib/delayed_resque/meta_data.rb
+++ b/lib/delayed_resque/meta_data.rb
@@ -1,0 +1,21 @@
+module DelayedResque
+  class MetaData
+    def self.store_meta_data(klass, args, meta = {})
+      Resque.redis.set(key(klass, args), Resque.encode(meta))
+    end
+
+    def self.load_meta_data(klass, args)
+      val = Resque.decode(Resque.redis.get(key(klass, args))) || {}
+      Rails.logger.debug("Loaded data #{key(klass, args).inspect} #{val.inspect}")
+      val
+    end
+
+    def self.delete_meta_data(klass, args)
+      Resque.redis.del(key(klass, args))
+    end
+
+    def self.key(klass, args)
+      "meta:#{Resque.encode('class' => klass.to_s, 'args' => args)}"
+    end
+  end
+end

--- a/lib/delayed_resque/meta_data.rb
+++ b/lib/delayed_resque/meta_data.rb
@@ -5,7 +5,7 @@ module DelayedResque
     end
 
     def self.load_meta_data(klass, args)
-      val = Resque.decode(Resque.redis.get(key(klass, args))) || {}
+      val = Resque.decode(Resque.redis.get(key(klass, args)))
       Rails.logger.debug("Loaded data #{key(klass, args).inspect} #{val.inspect}")
       val
     end

--- a/lib/delayed_resque/meta_data.rb
+++ b/lib/delayed_resque/meta_data.rb
@@ -1,7 +1,7 @@
 module DelayedResque
   class MetaData
     def self.store_meta_data(klass, args, meta = {})
-      Resque.redis.set(key(klass, args), Resque.encode(meta))
+      Resque.redis.set(key(klass, args), Resque.encode(meta), ex: 30.days.to_i)
     end
 
     def self.load_meta_data(klass, args)

--- a/lib/delayed_resque/performable_method.rb
+++ b/lib/delayed_resque/performable_method.rb
@@ -69,7 +69,11 @@ module DelayedResque
     end
 
     def store
-      {"obj" => @object, "method" => @method, "args" => @args}.merge(@options[:params] || {})
+      hsh = {"obj" => @object, "method" => @method, "args" => @args}.merge(@options[:params] || {})	      
+      unless @options[:unique] || @options[:throttle] || @options[:at] || @options[:in]	        # tracked jobs need to re-queue themselves
+        hsh["t"] = Time.now.to_f
+      end
+      hsh
     end
 
     private

--- a/lib/delayed_resque/performable_method.rb
+++ b/lib/delayed_resque/performable_method.rb
@@ -23,9 +23,16 @@ module DelayedResque
     end
 
     def self.queue
-      "default"
+      @queue || "default"
     end
-    
+        
+    def self.with_queue(queue)
+      old_queue = @queue
+      @queue = queue
+      yield
+      @queue = old_queue
+    end
+
     def self.perform(options)
       object = options["obj"]
       method = options["method"]

--- a/lib/delayed_resque/performable_method.rb
+++ b/lib/delayed_resque/performable_method.rb
@@ -30,6 +30,7 @@ module DelayedResque
       old_queue = @queue
       @queue = queue
       yield
+    ensure
       @queue = old_queue
     end
 

--- a/lib/delayed_resque/version.rb
+++ b/lib/delayed_resque/version.rb
@@ -1,3 +1,3 @@
 module DelayedResque
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end

--- a/lib/delayed_resque/version.rb
+++ b/lib/delayed_resque/version.rb
@@ -1,3 +1,3 @@
 module DelayedResque
-  VERSION = "1.0.10"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Store meta-data separately from the description of the job so that uniqueness checks do not include the meta-data.

Use the correct queue when dequeuing items for uniqueness. Previously the code ended up using the default queue when dequeuing, and so didn't actually dequeue items.