### PR TITLE
PF-230-2-clean-up-git-ingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ capybara-*.html
 /public/system/*
 /coverage/
 /spec/tmp/*
-**.orig
+*.orig
 rerun.txt
 pickle-email-*.html
 test.db


### PR DESCRIPTION
Dearest Reviewer,

It is unclear what made these but ** is incorrect.

`: line 14: error parsing glob '**.orig': invalid use of **; must be one
path component`

Changes
Remove a *

Becker