### PR TITLE
ensure duplicate jobs in the non-default queue are detected when uniq…

### DIFF
--- a/lib/delayed_resque/performable_method.rb
+++ b/lib/delayed_resque/performable_method.rb
@@ -23,7 +23,15 @@ module DelayedResque
     end
 
     def self.queue
-      "default"
+      @queue || "default"
+    end
+
+    def self.with_queue(queue)
+      old_queue = @queue
+      @queue = queue
+      yield
+    ensure
+      @queue = old_queue
     end
     
     def self.perform(options)

--- a/lib/delayed_resque/version.rb
+++ b/lib/delayed_resque/version.rb
@@ -1,3 +1,3 @@
 module DelayedResque
-  VERSION = "1.0.9"
+  VERSION = "1.2.0"
 end

--- a/spec/delayed_resque_spec.rb
+++ b/spec/delayed_resque_spec.rb
@@ -135,6 +135,15 @@ describe DelayedResque do
       DummyObject.delay(:at => at_time + 2, :unique => true).first_method(123)
       DelayedResque::PerformableMethod.should have_schedule_size_of(1)
     end
+
+    it "can remove preceeding delayed jobs with a non-default queue" do
+      at_time = Time.now.utc + 10.minutes
+      DummyObject.delay(at: at_time, unique: true, queue: :send_audit).first_method(123)
+      DelayedResque::PerformableMethod.should have_scheduled({"obj"=>"CLASS:DummyObject", "method"=>:first_method, "args"=>[123]}).at(at_time).queue(:send_audit)
+      DelayedResque::PerformableMethod.should have_schedule_size_of(1).queue(:send_audit)
+      DummyObject.delay(at: at_time + 1, unique: true, queue: :send_audit).first_method(123)
+      DelayedResque::PerformableMethod.should have_schedule_size_of(1).queue(:send_audit)
+    end
   end
 
   context "throttled jobs" do


### PR DESCRIPTION
Deep within the code in `resque-scheduler` it tries to figure out the queue to use when finding duplicate jobs. It does not use the queue passed in as part of the options hash though, and instead looks at the `payload_class.queue` value, which is currently always `default`. As such, duplicate jobs are not detected between different queues.
https://github.com/resque/resque-scheduler/blob/v4.3.1/lib/resque/scheduler/delaying_extensions.rb#L142
https://github.com/resque/resque-scheduler/blob/v4.3.1/lib/resque/scheduler/delaying_extensions.rb#L261

To fix this, let's allow for a way to set the queue of the payload class (in this case `PerformableMethod`).